### PR TITLE
Fix github link

### DIFF
--- a/src/main/java/org/jboss/errai/starter/client/local/modules/SetupPage.html
+++ b/src/main/java/org/jboss/errai/starter/client/local/modules/SetupPage.html
@@ -9,7 +9,7 @@
             Welcome to the Errai Getting Started Guide! This guide is targeted toward users with little to no previous
             experience with Errai. It describes and explains some of the most commonly used features of Errai, using
             handy demos to explain every concept. In addition, the guide itself is also an Errai app! This means that
-            you can look through the source code at <a href="www.github.com/errai">Errai's Github repository</a> to see
+            you can look through the source code at <a href="http://www.github.com/errai">Errai's Github repository</a> to see
             how Errai's various features are used here. Without further ado, let's get started with Errai!
         </p>
 


### PR DESCRIPTION
There's a broken link in "Setting up your app" page:
- http://erraiframework.org/getting-started/index.html#SetupPage
