### PR TITLE
Standardize on LoginPage

### DIFF
--- a/src/main/java/org/jboss/errai/starter/client/local/modules/ErraiNavigationPage.html
+++ b/src/main/java/org/jboss/errai/starter/client/local/modules/ErraiNavigationPage.html
@@ -88,7 +88,7 @@
     </pre>
         <p>
             By default, the name of a page is the simple name of the class that declares it. In the above example, the
-            SignUpPage will fill the navigation panel whenever the browser’s location bar reads <code class="textblock">localhost:8888/errai-forge-demo/index.html<strong>#LoginPage</strong></code>
+            LoginPage will fill the navigation panel whenever the browser’s location bar reads <code class="textblock">localhost:8888/errai-forge-demo/index.html<strong>#LoginPage</strong></code>
             If you prefer a different page name, use the @Page annotation’s path attribute:
         </p>
         <h5>LoginPage.java</h5>

--- a/src/main/java/org/jboss/errai/starter/client/local/modules/ErraiNavigationPage.html
+++ b/src/main/java/org/jboss/errai/starter/client/local/modules/ErraiNavigationPage.html
@@ -88,17 +88,17 @@
     </pre>
         <p>
             By default, the name of a page is the simple name of the class that declares it. In the above example, the
-            SignUpPage will fill the navigation panel whenever the browser’s location bar reads <code class="textblock">localhost:8888/errai-forge-demo/index.html<strong>#SignUpPage</strong></code>
+            SignUpPage will fill the navigation panel whenever the browser’s location bar reads <code class="textblock">localhost:8888/errai-forge-demo/index.html<strong>#LoginPage</strong></code>
             If you prefer a different page name, use the @Page annotation’s path attribute:
         </p>
-        <h5>SignUpPage.java</h5>
+        <h5>LoginPage.java</h5>
     <pre class="code-snippet" data-language="java">
   @Page(path="login")
   public class LoginPage extends Composite {
 	// Some code...
   }
     </pre>
-        <p>Using this in our ErraiDemo example, the URL to the SignUpPage would look like<code class="textblock">localhost:8888/errai-forge-demo/index.html<strong>#login</strong></code>
+        <p>Using this in our ErraiDemo example, the URL to the LoginPage would look like<code class="textblock">localhost:8888/errai-forge-demo/index.html<strong>#login</strong></code>
         </p>
 
         <h4>Default Page</h4>


### PR DESCRIPTION
One section of the doc keeps using `SignUpPage` and `LoginPage` interchangeable. This commit fixes that.
